### PR TITLE
Fall back to credentials persisted by actions/checkout for the GitHub API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ set `GITHUB_TOKEN` environment variable for your GitHub Actions job:
 
 `GITHUB_ACTIONS_TOKEN` environment variable can be used instead of `GITHUB_TOKEN`.
 
+In GitHub Actions, the plugin usually works even without any token configuration.
+If no token is configured, the plugin falls back to the credentials
+persisted in `.git/config` by [`actions/checkout`](https://github.com/actions/checkout)
+(unless its `persist-credentials` input is disabled).
+
 To configure a GitHub token for local development,
 add `name.remal.github-repository-info.api-token` property to your `~/.gradle/gradle.properties` file:
 
@@ -143,3 +148,11 @@ name.remal.github-repository-info.api-token = <your github token here>
 
 This file is in [the Gradle User Home directory](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home),
 so it won't be committed.
+
+The token sources in priority order:
+
+1. `GITHUB_TOKEN` environment variable
+2. `GITHUB_ACTIONS_TOKEN` environment variable
+3. `name.remal.github-repository-info.api-token` Gradle property
+4. `name.remal.github-repository-info.api.token` Gradle property
+5. Credentials persisted in `.git/config` by [`actions/checkout`](https://github.com/actions/checkout)

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtils.java
@@ -1,0 +1,104 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static lombok.AccessLevel.PRIVATE;
+import static name.remal.gradle_plugins.toolkit.ObjectUtils.nullIfEmpty;
+import static name.remal.gradle_plugins.toolkit.StringUtils.trimRightWith;
+import static org.eclipse.jgit.transport.HttpConfig.EXTRA_HEADER;
+import static org.eclipse.jgit.transport.HttpConfig.HTTP;
+
+import java.util.Base64;
+import lombok.NoArgsConstructor;
+import org.eclipse.jgit.errors.ConfigInvalidException;
+import org.eclipse.jgit.lib.Config;
+import org.jspecify.annotations.Nullable;
+
+@NoArgsConstructor(access = PRIVATE)
+class GitHubApiTokenUtils {
+
+    /**
+     * Extracts a GitHub API token from a git config with credentials persisted by
+     * <a href="https://github.com/actions/checkout">{@code actions/checkout}</a>.
+     *
+     * <p>Only {@code extraheader} values of {@code [http "<url>"]} sections matching {@code githubServerUrl}
+     * are considered (trailing slashes and character case are ignored).
+     * A value must be an {@code Authorization} header with the {@code basic} scheme,
+     * and the token is the part of the Base64-decoded credentials after the first colon.
+     * Subsection-less {@code [http]} sections are deliberately ignored.
+     *
+     * <p>If multiple values match, the last successfully parsed one wins.
+     */
+    @Nullable
+    public static String extractGitHubApiTokenFromGitConfig(
+        String gitConfigText,
+        @Nullable String githubServerUrl
+    ) throws ConfigInvalidException {
+        if (githubServerUrl == null || githubServerUrl.isEmpty()) {
+            return null;
+        }
+
+        var gitConfig = new Config();
+        gitConfig.fromText(gitConfigText);
+
+        var expectedSubsection = trimRightWith(githubServerUrl, '/');
+
+        String token = null;
+        for (var subsection : gitConfig.getSubsections(HTTP)) {
+            if (!trimRightWith(subsection, '/').equalsIgnoreCase(expectedSubsection)) {
+                continue;
+            }
+
+            // Git semantics: the last value wins. With multiple case-variant subsections matching the same
+            // server URL, "last" means the last matching subsection, not strict file order. That's acceptable,
+            // as `actions/checkout` writes a single entry.
+            for (var extraHeader : gitConfig.getStringList(HTTP, subsection, EXTRA_HEADER)) {
+                var parsedToken = parseGitHubApiTokenFromExtraHeader(extraHeader);
+                if (parsedToken != null) {
+                    token = parsedToken;
+                }
+            }
+        }
+        return token;
+    }
+
+    @Nullable
+    private static String parseGitHubApiTokenFromExtraHeader(String extraHeader) {
+        var headerNameDelimPos = extraHeader.indexOf(':');
+        if (headerNameDelimPos < 0) {
+            return null;
+        }
+
+        var headerName = extraHeader.substring(0, headerNameDelimPos).trim();
+        if (!headerName.equalsIgnoreCase(AUTHORIZATION)) {
+            return null;
+        }
+
+        var headerValue = extraHeader.substring(headerNameDelimPos + 1).trim();
+        var schemeDelimPos = headerValue.indexOf(' ');
+        if (schemeDelimPos < 0) {
+            return null;
+        }
+
+        var scheme = headerValue.substring(0, schemeDelimPos);
+        if (!scheme.equalsIgnoreCase("basic")) {
+            return null;
+        }
+
+        final byte[] credentialsBytes;
+        try {
+            credentialsBytes = Base64.getDecoder().decode(headerValue.substring(schemeDelimPos + 1).trim());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+
+        var credentials = new String(credentialsBytes, UTF_8);
+        var credentialsDelimPos = credentials.indexOf(':');
+        if (credentialsDelimPos < 0) {
+            return null;
+        }
+
+        return nullIfEmpty(credentials.substring(credentialsDelimPos + 1));
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoExtensionBase.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoExtensionBase.java
@@ -1,8 +1,8 @@
 package name.remal.gradle_plugins.github_repository_info;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.readString;
 import static java.util.Comparator.comparing;
+import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfig;
 import static name.remal.gradle_plugins.toolkit.ConfigurationCacheSafeSystem.getConfigurationCacheSafeOptionalEnv;
 import static name.remal.gradle_plugins.toolkit.StringUtils.substringBefore;
 import static org.eclipse.jgit.lib.Constants.CONFIG;
@@ -26,6 +26,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Internal;
 import org.gradle.initialization.BuildCancellationToken;
+import org.jspecify.annotations.Nullable;
 
 abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfoSettings {
 
@@ -56,6 +57,7 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
                 .orElse(getProviders().provider(() -> getConfigurationCacheSafeOptionalEnv("GITHUB_ACTIONS_TOKEN")))
                 .orElse(getProviders().gradleProperty("name.remal.github-repository-info.api-token"))
                 .orElse(getProviders().gradleProperty("name.remal.github-repository-info.api.token"))
+                .orElse(getProviders().provider(this::readGitHubApiTokenFromGitConfig))
         );
         getGithubServerUrl().convention(
             getProviders().environmentVariable("GITHUB_SERVER_URL")
@@ -75,22 +77,8 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
     {
         var gitRemoteUri = getObjects().property(URIish.class);
         gitRemoteUri.value(getProviders().provider(() -> {
-            var gitConfigPath = getRepositoryRootDir()
-                .map(Directory::getAsFile)
-                .map(File::toPath)
-                .map(path -> path.resolve(DOT_GIT).resolve(CONFIG))
-                .getOrNull();
-            if (gitConfigPath == null) {
-                return null;
-            }
-
-            final Config config;
-            try {
-                var bytes = readAllBytes(gitConfigPath);
-                var text = new String(bytes, UTF_8);
-                config = new Config();
-                config.fromText(text);
-            } catch (NoSuchFileException ignored) {
+            var config = readRepositoryGitConfig();
+            if (config == null) {
                 return null;
             }
 
@@ -127,6 +115,47 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
                 .map(path -> substringBefore(path, DOT_GIT_EXT))
                 .map(ObjectUtils::nullIfEmpty)
         ).finalizeValueOnRead();
+    }
+
+
+    @Nullable
+    private String readGitHubApiTokenFromGitConfig() throws Exception {
+        var configText = readRepositoryGitConfigText();
+        if (configText == null) {
+            return null;
+        }
+
+        return extractGitHubApiTokenFromGitConfig(configText, getGithubServerUrl().getOrNull());
+    }
+
+    @Nullable
+    private Config readRepositoryGitConfig() throws Exception {
+        var configText = readRepositoryGitConfigText();
+        if (configText == null) {
+            return null;
+        }
+
+        var config = new Config();
+        config.fromText(configText);
+        return config;
+    }
+
+    @Nullable
+    private String readRepositoryGitConfigText() throws Exception {
+        var gitConfigPath = getRepositoryRootDir()
+            .map(Directory::getAsFile)
+            .map(File::toPath)
+            .map(path -> path.resolve(DOT_GIT).resolve(CONFIG))
+            .getOrNull();
+        if (gitConfigPath == null) {
+            return null;
+        }
+
+        try {
+            return readString(gitConfigPath);
+        } catch (NoSuchFileException ignored) {
+            return null;
+        }
     }
 
 

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtilsTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtilsTest.java
@@ -1,0 +1,231 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfig;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+class GitHubApiTokenUtilsTest {
+
+    private static final String GITHUB_SERVER_URL = "https://github.com";
+
+    @Test
+    void tokenPersistedByCheckoutActionIsExtracted() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void trailingSlashesOfSubsectionAndServerUrlAreIgnored() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, "https://github.com/"));
+    }
+
+    @Test
+    void subsectionIsMatchedCaseInsensitively() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://GitHub.COM/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void headerNameIsMatchedCaseInsensitively() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = authorization: basic " + base64("x-access-token:token-value")
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void schemeIsMatchedCaseInsensitively() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = AUTHORIZATION: Basic " + base64("x-access-token:token-value")
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void colonsInsideTokenArePreserved() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token:with:colons")
+        );
+
+        assertEquals("token:with:colons", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void lastValueWins() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:first-token"),
+            "\textraheader = " + basicExtraHeader("x-access-token:second-token")
+        );
+
+        assertEquals("second-token", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void unparseableValueDoesNotOverridePrecedingParsedValue() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value"),
+            "\textraheader = AUTHORIZATION: bearer some-token"
+        );
+
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+    }
+
+    @Test
+    void notMatchingSubsectionProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.example.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from a section of another server URL"
+        );
+    }
+
+    @Test
+    void notAuthorizationHeaderProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = X-Custom-Header: basic " + base64("x-access-token:token-value")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from a header other than Authorization"
+        );
+    }
+
+    @Test
+    void notBasicSchemeProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = AUTHORIZATION: bearer some-token"
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from a scheme other than basic"
+        );
+    }
+
+    @Test
+    void invalidBase64ProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = AUTHORIZATION: basic !!!not-base64!!!"
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from invalid Base64 credentials"
+        );
+    }
+
+    @Test
+    void credentialsWithoutColonProduceNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("credentials-without-colon")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from credentials without a colon"
+        );
+    }
+
+    @Test
+    void emptyTokenProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "empty token extracted"
+        );
+    }
+
+    @Test
+    void subsectionLessHttpSectionIsIgnored() throws Throwable {
+        var config = gitConfig(
+            "[http]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from a subsection-less [http] section"
+        );
+    }
+
+    @Test
+    void configWithoutHttpSectionProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[remote \"origin\"]",
+            "\turl = https://github.com/remal-gradle-plugins/github-repository-info"
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            "token extracted from a config without [http] sections"
+        );
+    }
+
+    @Test
+    void nullOrEmptyServerUrlProducesNoToken() throws Throwable {
+        var config = gitConfig(
+            "[http \"https://github.com/\"]",
+            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, null),
+            "token extracted for a null server URL"
+        );
+        assertNull(
+            extractGitHubApiTokenFromGitConfig(config, ""),
+            "token extracted for an empty server URL"
+        );
+    }
+
+
+    private static String gitConfig(String... lines) {
+        return String.join("\n", lines) + "\n";
+    }
+
+    private static String basicExtraHeader(String rawCredentials) {
+        return "AUTHORIZATION: basic " + base64(rawCredentials);
+    }
+
+    private static String base64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
+    }
+
+}

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoPluginTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoPluginTest.java
@@ -1,12 +1,20 @@
 package name.remal.gradle_plugins.github_repository_info;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.writeString;
 import static name.remal.gradle_plugins.toolkit.reflection.ReflectionUtils.packageNameOf;
 import static name.remal.gradle_plugins.toolkit.reflection.ReflectionUtils.unwrapGeneratedSubclass;
 import static name.remal.gradle_plugins.toolkit.testkit.ProjectValidations.executeAfterEvaluateActions;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +24,10 @@ import name.remal.gradle_plugins.github_repository_info.info.GitHubLicenseConten
 import name.remal.gradle_plugins.toolkit.testkit.TaskValidations;
 import org.gradle.api.Project;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @RequiredArgsConstructor
 @SuppressWarnings("java:S5778")
@@ -65,6 +76,76 @@ class GitHubRepositoryInfoPluginTest {
             var taskClass = unwrapGeneratedSubclass(task.getClass());
             return taskClass.getName().startsWith(taskClassNamePrefix);
         }).map(TaskValidations::markTaskDependenciesAsSkipped).forEach(TaskValidations::assertNoTaskPropertiesProblems);
+    }
+
+    @Nested
+    class GithubApiTokenFromGitConfig {
+
+        private static final String SYNTHETIC_TOKEN = "synthetic-git-config-token";
+
+        GitHubRepositoryInfoExtension extension;
+
+        @BeforeEach
+        void beforeEach() {
+            extension = project.getExtensions().getByType(GitHubRepositoryInfoExtension.class);
+            extension.getRepositoryRootDir().fileValue(project.getProjectDir());
+            extension.getGithubServerUrl().set("https://github.com");
+        }
+
+        @Test
+        @DisabledIfEnvironmentVariable(named = "GITHUB_TOKEN", matches = ".+")
+        @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
+        void tokenIsReadFromRepositoryGitConfig() throws Throwable {
+            writeProjectGitConfig(
+                "[http \"https://github.com/\"]",
+                "\textraheader = AUTHORIZATION: basic " + base64("x-access-token:" + SYNTHETIC_TOKEN)
+            );
+
+            assertEquals(SYNTHETIC_TOKEN, extension.getGithubApiToken().getOrNull());
+        }
+
+        @Test
+        @EnabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
+        void environmentVariableWinsOverGitConfig() throws Throwable {
+            writeProjectGitConfig(
+                "[http \"https://github.com/\"]",
+                "\textraheader = AUTHORIZATION: basic " + base64("x-access-token:" + SYNTHETIC_TOKEN)
+            );
+
+            var expectedToken = System.getenv("GITHUB_TOKEN") != null
+                ? System.getenv("GITHUB_TOKEN")
+                : System.getenv("GITHUB_ACTIONS_TOKEN");
+            var token = extension.getGithubApiToken().getOrNull();
+            assertNotEquals(SYNTHETIC_TOKEN, token, "git config token must not win over environment variables");
+            assertEquals(expectedToken, token);
+        }
+
+        @Test
+        @DisabledIfEnvironmentVariable(named = "GITHUB_TOKEN", matches = ".+")
+        @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
+        void tokenIsAbsentWhenGitConfigHasNoExtraHeader() throws Throwable {
+            writeProjectGitConfig(
+                "[remote \"origin\"]",
+                "\turl = https://github.com/remal-gradle-plugins/github-repository-info"
+            );
+
+            assertNull(
+                extension.getGithubApiToken().getOrNull(),
+                "githubApiToken resolved without any token source"
+            );
+        }
+
+
+        private void writeProjectGitConfig(String... lines) throws IOException {
+            var gitConfigPath = project.getProjectDir().toPath().resolve(".git").resolve("config");
+            createDirectories(gitConfigPath.getParent());
+            writeString(gitConfigPath, String.join("\n", lines) + "\n");
+        }
+
+        private String base64(String value) {
+            return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
+        }
+
     }
 
 }


### PR DESCRIPTION
## Summary

In GitHub Actions, the plugin runs unauthenticated and hits API rate limits unless the workflow wires a token manually, even though `actions/checkout` already persists the job token in `.git/config`. Falling back to those persisted credentials makes the plugin work in GitHub Actions with zero configuration.