### PR TITLE
Replace JGit with the git CLI for reading repository git config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,12 +167,31 @@ jobs:
       java-gradle-only-once: false
 
   # $$$sync-with-template-modifiable: cross-versions-additional-tests $$$
+  cross-versions-tests-windows:
+    needs:
+    - build
+    uses: ./.github/workflows/build-test.yml
+    secrets: inherit
+    with:
+      os: windows
+      env-json: ${{needs.build.outputs.env-json}}
+
+  cross-versions-tests-macos:
+    needs:
+    - build
+    uses: ./.github/workflows/build-test.yml
+    secrets: inherit
+    with:
+      os: macos
+      env-json: ${{needs.build.outputs.env-json}}
   # $$$sync-with-template-modifiable-end$$$
 
   cross-versions-tests-success:
     needs:
     - cross-versions-tests
     # $$$sync-with-template-modifiable: cross-versions-additional-tests-dependents $$$
+    - cross-versions-tests-windows
+    - cross-versions-tests-macos
     # $$$sync-with-template-modifiable-end$$$
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -136,8 +136,13 @@ set `GITHUB_TOKEN` environment variable for your GitHub Actions job:
 
 In GitHub Actions, the plugin usually works even without any token configuration.
 If no token is configured, the plugin falls back to the credentials
-persisted in `.git/config` by [`actions/checkout`](https://github.com/actions/checkout)
+persisted in the repository git config by [`actions/checkout`](https://github.com/actions/checkout)
 (unless its `persist-credentials` input is disabled).
+The plugin invokes the `git` CLI (`git config --local --includes --list`) to read the repository config,
+so the credentials are found for all `actions/checkout` layouts:
+both the direct `extraheader` value and the newer credentials file referenced via `includeIf`.
+The `git` executable is required on `PATH` when these values are needed
+(the build fails with a clear error otherwise; `includeIf` resolution requires git 2.13+).
 
 To configure a GitHub token for local development,
 add `name.remal.github-repository-info.api-token` property to your `~/.gradle/gradle.properties` file:
@@ -155,4 +160,4 @@ The token sources in priority order:
 2. `GITHUB_ACTIONS_TOKEN` environment variable
 3. `name.remal.github-repository-info.api-token` Gradle property
 4. `name.remal.github-repository-info.api.token` Gradle property
-5. Credentials persisted in `.git/config` by [`actions/checkout`](https://github.com/actions/checkout)
+5. Credentials persisted in the repository git config by [`actions/checkout`](https://github.com/actions/checkout) (read via the git CLI, following `include`/`includeIf`)

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,6 @@ testSourceSets.create('componentTest')
 
 dependencies {
     classesRelocation 'com.google.code.gson:gson:2.14.0'
-    classesRelocation('org.eclipse.jgit:org.eclipse.jgit:6.10.1.202505221210-r') {
-        exclude group: 'org.slf4j'
-    }
 }
 
 gradlePlugin {

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntries.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntries.java
@@ -1,0 +1,21 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+/**
+ * Git config entries relevant to the plugin, resolved by {@link GitConfigValueSource}.
+ */
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+class GitConfigEntries implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    List<GitConfigEntry> entries;
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntries.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntries.java
@@ -12,6 +12,7 @@ import lombok.Value;
 @Value
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
+@SuppressWarnings("java:S1948")
 class GitConfigEntries implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntry.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigEntry.java
@@ -1,0 +1,34 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A single resolved git config entry.
+ *
+ * <p>Git normalizes the {@link #section} and the {@link #name} to lower case,
+ * while the {@link #subsection} keeps its original character case.
+ *
+ * <p>A null {@link #value} means a value-less entry (a config name without {@code =}).
+ */
+@Value
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+class GitConfigEntry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    String section;
+
+    @Nullable
+    String subsection;
+
+    String name;
+
+    @Nullable
+    String value;
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigOutputUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigOutputUtils.java
@@ -1,0 +1,57 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.google.common.base.Splitter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+class GitConfigOutputUtils {
+
+    private static final Splitter NUL_SPLITTER = Splitter.on('\0');
+
+    /**
+     * Parses the output of {@code git config --list --null} into entries in their original order.
+     *
+     * <p>Every entry consists of a config key and an optional value delimited with the first {@code \n} character
+     * and is terminated with a NUL character.
+     * The value may contain further {@code \n} characters.
+     */
+    public static List<GitConfigEntry> parseGitConfigNullOutput(String output) {
+        var entries = new ArrayList<GitConfigEntry>();
+        for (var chunk : NUL_SPLITTER.split(output)) {
+            if (chunk.isEmpty()) {
+                continue;
+            }
+
+            final String key;
+            final String value;
+            var keyDelimPos = chunk.indexOf('\n');
+            if (keyDelimPos >= 0) {
+                key = chunk.substring(0, keyDelimPos);
+                value = chunk.substring(keyDelimPos + 1);
+            } else {
+                key = chunk;
+                value = null;
+            }
+
+            var sectionDelimPos = key.indexOf('.');
+            if (sectionDelimPos < 0) {
+                // a git config key always consists of at least a section and a name
+                continue;
+            }
+            var nameDelimPos = key.lastIndexOf('.');
+
+            var section = key.substring(0, sectionDelimPos);
+            var subsection = sectionDelimPos < nameDelimPos
+                ? key.substring(sectionDelimPos + 1, nameDelimPos)
+                : null;
+            var name = key.substring(nameDelimPos + 1);
+            entries.add(new GitConfigEntry(section, subsection, name, value));
+        }
+        return entries;
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigReadException.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigReadException.java
@@ -1,0 +1,13 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+class GitConfigReadException extends RuntimeException {
+
+    GitConfigReadException(String message) {
+        super(message);
+    }
+
+    GitConfigReadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigValueSource.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitConfigValueSource.java
@@ -1,0 +1,112 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static lombok.AccessLevel.PUBLIC;
+import static name.remal.gradle_plugins.github_repository_info.GitConfigOutputUtils.parseGitConfigNullOutput;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import javax.inject.Inject;
+import lombok.NoArgsConstructor;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.ValueSource;
+import org.gradle.api.provider.ValueSourceParameters;
+import org.gradle.process.ExecOperations;
+import org.gradle.process.ExecResult;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reads the repository git config by executing the {@code git} CLI.
+ *
+ * <p>Delegating to the CLI makes git itself resolve {@code include} and {@code includeIf} directives,
+ * so credentials persisted by all {@code actions/checkout} versions are found
+ * (new versions persist credentials in a separate file referenced via {@code includeIf}).
+ *
+ * <p>Only the entries the plugin consumes are returned,
+ * which keeps the configuration cache input of this value source small.
+ */
+@NoArgsConstructor(access = PUBLIC, onConstructor_ = {@Inject})
+abstract class GitConfigValueSource implements ValueSource<GitConfigEntries, GitConfigValueSource.Parameters> {
+
+    interface Parameters extends ValueSourceParameters {
+        DirectoryProperty getRepositoryRootDir();
+    }
+
+
+    private static final List<String> GIT_CONFIG_COMMAND = List.of(
+        "git", "config", "--local", "--includes", "--list", "--null"
+    );
+
+    private static final String EXPLICIT_VALUES_HINT =
+        "Alternatively, provide the GitHub repository information explicitly"
+            + " via the GITHUB_TOKEN / GITHUB_REPOSITORY / GITHUB_SERVER_URL environment variables"
+            + " or the `name.remal.github-repository-info.*` Gradle properties.";
+
+    private static final String HTTP = "http";
+    private static final String EXTRA_HEADER = "extraheader";
+    private static final String REMOTE = "remote";
+    private static final String URL = "url";
+
+
+    @Inject
+    protected abstract ExecOperations getExecOperations();
+
+    @Nullable
+    @Override
+    public GitConfigEntries obtain() {
+        var repositoryRootDir = getParameters().getRepositoryRootDir().getAsFile().getOrNull();
+        if (repositoryRootDir == null) {
+            return null;
+        }
+
+        var stdout = new ByteArrayOutputStream();
+        var stderr = new ByteArrayOutputStream();
+        final ExecResult execResult;
+        try {
+            execResult = getExecOperations().exec(spec -> {
+                spec.commandLine(GIT_CONFIG_COMMAND);
+                spec.setWorkingDir(repositoryRootDir);
+                spec.setStandardOutput(stdout);
+                spec.setErrorOutput(stderr);
+                spec.setIgnoreExitValue(true);
+            });
+        } catch (Exception exception) {
+            throw new GitConfigReadException(
+                format(
+                    "Failed to execute `%s` in `%s` to read the repository git config."
+                        + " Install git and make sure the `git` executable is available on PATH. %s",
+                    join(" ", GIT_CONFIG_COMMAND),
+                    repositoryRootDir,
+                    EXPLICIT_VALUES_HINT
+                ),
+                exception
+            );
+        }
+
+        var exitValue = execResult.getExitValue();
+        if (exitValue != 0) {
+            throw new GitConfigReadException(format(
+                "`%s` executed in `%s` failed with exit code %d. %s%nGit error output:%n%s",
+                join(" ", GIT_CONFIG_COMMAND),
+                repositoryRootDir,
+                exitValue,
+                EXPLICIT_VALUES_HINT,
+                stderr.toString(UTF_8)
+            ));
+        }
+
+        var entries = parseGitConfigNullOutput(stdout.toString(UTF_8)).stream()
+            .filter(GitConfigValueSource::isRelevantEntry)
+            .collect(toUnmodifiableList());
+        return new GitConfigEntries(entries);
+    }
+
+    private static boolean isRelevantEntry(GitConfigEntry entry) {
+        return (entry.getSection().equals(HTTP) && entry.getName().equals(EXTRA_HEADER))
+            || (entry.getSection().equals(REMOTE) && entry.getName().equals(URL));
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtils.java
@@ -5,20 +5,20 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static lombok.AccessLevel.PRIVATE;
 import static name.remal.gradle_plugins.toolkit.ObjectUtils.nullIfEmpty;
 import static name.remal.gradle_plugins.toolkit.StringUtils.trimRightWith;
-import static org.eclipse.jgit.transport.HttpConfig.EXTRA_HEADER;
-import static org.eclipse.jgit.transport.HttpConfig.HTTP;
 
 import java.util.Base64;
+import java.util.List;
 import lombok.NoArgsConstructor;
-import org.eclipse.jgit.errors.ConfigInvalidException;
-import org.eclipse.jgit.lib.Config;
 import org.jspecify.annotations.Nullable;
 
 @NoArgsConstructor(access = PRIVATE)
 class GitHubApiTokenUtils {
 
+    private static final String HTTP = "http";
+    private static final String EXTRA_HEADER = "extraheader";
+
     /**
-     * Extracts a GitHub API token from a git config with credentials persisted by
+     * Extracts a GitHub API token from resolved git config entries with credentials persisted by
      * <a href="https://github.com/actions/checkout">{@code actions/checkout}</a>.
      *
      * <p>Only {@code extraheader} values of {@code [http "<url>"]} sections matching {@code githubServerUrl}
@@ -30,33 +30,38 @@ class GitHubApiTokenUtils {
      * <p>If multiple values match, the last successfully parsed one wins.
      */
     @Nullable
-    public static String extractGitHubApiTokenFromGitConfig(
-        String gitConfigText,
+    public static String extractGitHubApiTokenFromGitConfigEntries(
+        List<GitConfigEntry> gitConfigEntries,
         @Nullable String githubServerUrl
-    ) throws ConfigInvalidException {
+    ) {
         if (githubServerUrl == null || githubServerUrl.isEmpty()) {
             return null;
         }
 
-        var gitConfig = new Config();
-        gitConfig.fromText(gitConfigText);
-
         var expectedSubsection = trimRightWith(githubServerUrl, '/');
 
         String token = null;
-        for (var subsection : gitConfig.getSubsections(HTTP)) {
-            if (!trimRightWith(subsection, '/').equalsIgnoreCase(expectedSubsection)) {
+        for (var entry : gitConfigEntries) {
+            if (!entry.getSection().equals(HTTP)
+                || !entry.getName().equals(EXTRA_HEADER)
+            ) {
                 continue;
             }
 
-            // Git semantics: the last value wins. With multiple case-variant subsections matching the same
-            // server URL, "last" means the last matching subsection, not strict file order. That's acceptable,
-            // as `actions/checkout` writes a single entry.
-            for (var extraHeader : gitConfig.getStringList(HTTP, subsection, EXTRA_HEADER)) {
-                var parsedToken = parseGitHubApiTokenFromExtraHeader(extraHeader);
-                if (parsedToken != null) {
-                    token = parsedToken;
-                }
+            var subsection = entry.getSubsection();
+            if (subsection == null || !trimRightWith(subsection, '/').equalsIgnoreCase(expectedSubsection)) {
+                continue;
+            }
+
+            var extraHeader = entry.getValue();
+            if (extraHeader == null) {
+                continue;
+            }
+
+            // Git semantics: the last value wins. The entries come in git's own resolution order.
+            var parsedToken = parseGitHubApiTokenFromExtraHeader(extraHeader);
+            if (parsedToken != null) {
+                token = parsedToken;
             }
         }
         return token;

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubDataFetcher.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubDataFetcher.java
@@ -1,5 +1,6 @@
 package name.remal.gradle_plugins.github_repository_info;
 
+import static com.google.common.hash.Hashing.sha512;
 import static com.google.common.net.HttpHeaders.ACCEPT;
 import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static com.google.common.net.HttpHeaders.ACCEPT_LANGUAGE;
@@ -14,7 +15,6 @@ import static name.remal.gradle_plugins.github_repository_info.JsonUtils.GSON;
 import static name.remal.gradle_plugins.toolkit.ConfigurationCacheSafeSystem.getConfigurationCacheSafeBooleanEnv;
 import static name.remal.gradle_plugins.toolkit.InTestFlags.isInTest;
 import static name.remal.gradle_plugins.toolkit.PathUtils.normalizePath;
-import static org.apache.commons.codec.digest.DigestUtils.sha512Hex;
 
 import com.google.gson.reflect.TypeToken;
 import java.net.URI;
@@ -80,7 +80,7 @@ abstract class GitHubDataFetcher implements BuildService<GitHubDataFetcherParams
             return null;
         }
 
-        var hash = sha512Hex(fullUrl.getBytes(UTF_8));
+        var hash = sha512().hashBytes(fullUrl.getBytes(UTF_8)).toString();
         return cacheDir.resolve(hash + ".json");
     }
 

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoExtensionBase.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoExtensionBase.java
@@ -1,34 +1,28 @@
 package name.remal.gradle_plugins.github_repository_info;
 
-import static java.nio.file.Files.readString;
 import static java.util.Comparator.comparing;
-import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfig;
+import static java.util.Objects.requireNonNull;
+import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfigEntries;
 import static name.remal.gradle_plugins.toolkit.ConfigurationCacheSafeSystem.getConfigurationCacheSafeOptionalEnv;
-import static name.remal.gradle_plugins.toolkit.StringUtils.substringBefore;
-import static org.eclipse.jgit.lib.Constants.CONFIG;
-import static org.eclipse.jgit.lib.Constants.DEFAULT_REMOTE_NAME;
-import static org.eclipse.jgit.lib.Constants.DOT_GIT;
-import static org.eclipse.jgit.lib.Constants.DOT_GIT_EXT;
-import static org.eclipse.jgit.transport.RemoteConfig.getAllRemoteConfigs;
 
-import java.io.File;
-import java.nio.file.NoSuchFileException;
-import java.util.Collection;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Objects;
 import javax.inject.Inject;
-import name.remal.gradle_plugins.toolkit.ObjectUtils;
-import org.eclipse.jgit.lib.Config;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.URIish;
-import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Internal;
 import org.gradle.initialization.BuildCancellationToken;
-import org.jspecify.annotations.Nullable;
 
 abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfoSettings {
+
+    private static final String DEFAULT_REMOTE_NAME = "origin";
+
+    private static final String REMOTE = "remote";
+    private static final String URL = "url";
+
 
     @Internal
     protected abstract Property<GitHubDataFetcher> getGitHubDataFetcher();
@@ -39,6 +33,11 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
 
     @Internal
     public abstract Property<String> getGithubServerUrl();
+
+    private final Provider<GitConfigEntries> repositoryGitConfigEntries = getProviders().of(
+        GitConfigValueSource.class,
+        spec -> spec.getParameters().getRepositoryRootDir().set(getRepositoryRootDir())
+    );
 
     {
         getGithubApiUrl().convention(
@@ -57,7 +56,7 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
                 .orElse(getProviders().provider(() -> getConfigurationCacheSafeOptionalEnv("GITHUB_ACTIONS_TOKEN")))
                 .orElse(getProviders().gradleProperty("name.remal.github-repository-info.api-token"))
                 .orElse(getProviders().gradleProperty("name.remal.github-repository-info.api.token"))
-                .orElse(getProviders().provider(this::readGitHubApiTokenFromGitConfig))
+                .orElse(getGitHubApiTokenFromGitConfig())
         );
         getGithubServerUrl().convention(
             getProviders().environmentVariable("GITHUB_SERVER_URL")
@@ -65,6 +64,21 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
                 .orElse(getProviders().gradleProperty("name.remal.github-repository-info.server-url"))
                 .orElse("https://github.com")
         );
+    }
+
+    @VisibleForTesting
+    Provider<String> getGitHubApiTokenFromGitConfig() {
+        return getProviders().provider(() -> {
+            var gitConfigEntries = repositoryGitConfigEntries.getOrNull();
+            if (gitConfigEntries == null) {
+                return null;
+            }
+
+            return extractGitHubApiTokenFromGitConfigEntries(
+                gitConfigEntries.getEntries(),
+                getGithubServerUrl().getOrNull()
+            );
+        });
     }
 
 
@@ -75,87 +89,43 @@ abstract class GitHubRepositoryInfoExtensionBase implements GitHubRepositoryInfo
     protected abstract Property<String> getGitRemoteRepositoryFullName();
 
     {
-        var gitRemoteUri = getObjects().property(URIish.class);
-        gitRemoteUri.value(getProviders().provider(() -> {
-            var config = readRepositoryGitConfig();
-            if (config == null) {
+        var gitRemoteUrl = getObjects().property(String.class);
+        gitRemoteUrl.value(getProviders().provider(() -> {
+            var gitConfigEntries = repositoryGitConfigEntries.getOrNull();
+            if (gitConfigEntries == null) {
                 return null;
             }
 
-            var remotes = getAllRemoteConfigs(config);
-            var remotesComparator = comparing(RemoteConfig::getName, (name1, name2) -> {
-                if (name1.equals(name2)) {
-                    return 0;
-                } else if (name1.equals(DEFAULT_REMOTE_NAME)) {
-                    return -1;
-                } else if (name2.equals(DEFAULT_REMOTE_NAME)) {
-                    return 1;
-                } else {
-                    return 0;
+            var remoteNamesComparator = comparing(
+                (GitConfigEntry entry) -> requireNonNull(entry.getSubsection()),
+                (name1, name2) -> {
+                    if (Objects.equals(name1, name2)) {
+                        return 0;
+                    } else if (Objects.equals(name1, DEFAULT_REMOTE_NAME)) {
+                        return -1;
+                    } else if (Objects.equals(name2, DEFAULT_REMOTE_NAME)) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
                 }
-            });
-            return remotes.stream()
-                .sorted(remotesComparator)
-                .map(RemoteConfig::getURIs)
-                .flatMap(Collection::stream)
+            );
+            return gitConfigEntries.getEntries().stream()
+                .filter(entry -> entry.getSection().equals(REMOTE) && entry.getName().equals(URL))
+                .filter(entry -> entry.getSubsection() != null && entry.getValue() != null)
+                .sorted(remoteNamesComparator)
+                .map(GitConfigEntry::getValue)
                 .findFirst()
                 .orElse(null);
         })).finalizeValueOnRead();
 
         getGitRemoteHost().value(
-            gitRemoteUri
-                .map(URIish::getHost)
-                .map(ObjectUtils::nullIfEmpty)
+            gitRemoteUrl.map(GitRemoteUrlUtils::getRemoteUrlHost)
         ).finalizeValueOnRead();
 
         getGitRemoteRepositoryFullName().value(
-            gitRemoteUri
-                .map(URIish::getRawPath)
-                .map(path -> path.startsWith("/") ? path.substring(1) : path)
-                .map(path -> substringBefore(path, DOT_GIT_EXT))
-                .map(ObjectUtils::nullIfEmpty)
+            gitRemoteUrl.map(GitRemoteUrlUtils::getRemoteUrlPath)
         ).finalizeValueOnRead();
-    }
-
-
-    @Nullable
-    private String readGitHubApiTokenFromGitConfig() throws Exception {
-        var configText = readRepositoryGitConfigText();
-        if (configText == null) {
-            return null;
-        }
-
-        return extractGitHubApiTokenFromGitConfig(configText, getGithubServerUrl().getOrNull());
-    }
-
-    @Nullable
-    private Config readRepositoryGitConfig() throws Exception {
-        var configText = readRepositoryGitConfigText();
-        if (configText == null) {
-            return null;
-        }
-
-        var config = new Config();
-        config.fromText(configText);
-        return config;
-    }
-
-    @Nullable
-    private String readRepositoryGitConfigText() throws Exception {
-        var gitConfigPath = getRepositoryRootDir()
-            .map(Directory::getAsFile)
-            .map(File::toPath)
-            .map(path -> path.resolve(DOT_GIT).resolve(CONFIG))
-            .getOrNull();
-        if (gitConfigPath == null) {
-            return null;
-        }
-
-        try {
-            return readString(gitConfigPath);
-        } catch (NoSuchFileException ignored) {
-            return null;
-        }
     }
 
 

--- a/src/main/java/name/remal/gradle_plugins/github_repository_info/GitRemoteUrlUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/github_repository_info/GitRemoteUrlUtils.java
@@ -1,0 +1,113 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static lombok.AccessLevel.PRIVATE;
+import static name.remal.gradle_plugins.toolkit.ObjectUtils.nullIfEmpty;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
+
+@NoArgsConstructor(access = PRIVATE)
+class GitRemoteUrlUtils {
+
+    private static final String DOT_GIT_EXT = ".git";
+
+    /**
+     * Extracts the host from a git remote URL.
+     *
+     * <p>Standard scheme URLs (like {@code https://}, {@code ssh://}, or {@code git://})
+     * and the scp-like syntax ({@code [user@]host:path}) are supported.
+     * Local paths produce no host.
+     */
+    @Nullable
+    public static String getRemoteUrlHost(String remoteUrl) {
+        if (hasScheme(remoteUrl)) {
+            try {
+                return nullIfEmpty(new URI(remoteUrl).getHost());
+            } catch (URISyntaxException ignored) {
+                return null;
+            }
+        }
+
+        var scpDelimPos = getScpLikeSyntaxDelimPos(remoteUrl);
+        if (scpDelimPos >= 0) {
+            var authority = remoteUrl.substring(0, scpDelimPos);
+            var userDelimPos = authority.lastIndexOf('@');
+            return nullIfEmpty(authority.substring(userDelimPos + 1));
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the repository path from a git remote URL.
+     *
+     * <p>The leading slash and the trailing {@code .git} extension are stripped.
+     * An empty path produces null.
+     */
+    @Nullable
+    public static String getRemoteUrlPath(String remoteUrl) {
+        var rawPath = getRemoteUrlRawPath(remoteUrl);
+        if (rawPath == null) {
+            return null;
+        }
+
+        var path = rawPath;
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        if (path.endsWith(DOT_GIT_EXT)) {
+            path = path.substring(0, path.length() - DOT_GIT_EXT.length());
+        }
+        return nullIfEmpty(path);
+    }
+
+
+    @Nullable
+    private static String getRemoteUrlRawPath(String remoteUrl) {
+        if (hasScheme(remoteUrl)) {
+            try {
+                return new URI(remoteUrl).getPath();
+            } catch (URISyntaxException ignored) {
+                return null;
+            }
+        }
+
+        var scpDelimPos = getScpLikeSyntaxDelimPos(remoteUrl);
+        if (scpDelimPos >= 0) {
+            return remoteUrl.substring(scpDelimPos + 1);
+        }
+
+        return remoteUrl;
+    }
+
+    private static boolean hasScheme(String remoteUrl) {
+        return remoteUrl.contains("://");
+    }
+
+    /**
+     * Returns the position of the colon delimiting the scp-like syntax ({@code [user@]host:path}),
+     * or a negative value for other remote URL formats.
+     */
+    private static int getScpLikeSyntaxDelimPos(String remoteUrl) {
+        var colonPos = remoteUrl.indexOf(':');
+        if (colonPos <= 0) {
+            return -1;
+        }
+
+        var slashPos = remoteUrl.indexOf('/');
+        if (slashPos >= 0 && slashPos < colonPos) {
+            return -1;
+        }
+
+        var userDelimPos = remoteUrl.lastIndexOf('@', colonPos - 1);
+        if (userDelimPos < 0 && colonPos == 1) {
+            // a single character before the colon is a Windows drive letter, not a host
+            return -1;
+        }
+
+        return colonPos;
+    }
+
+}

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitConfigOutputUtilsTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitConfigOutputUtilsTest.java
@@ -1,0 +1,96 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static name.remal.gradle_plugins.github_repository_info.GitConfigOutputUtils.parseGitConfigNullOutput;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class GitConfigOutputUtilsTest {
+
+    @Test
+    void entriesAreSplitOnNulCharacters() {
+        var entries = parseGitConfigNullOutput(
+            "core.bare\nfalse\0remote.origin.url\nhttps://github.com/owner/repo\0"
+        );
+
+        assertEquals(
+            List.of(
+                new GitConfigEntry("core", null, "bare", "false"),
+                new GitConfigEntry("remote", "origin", "url", "https://github.com/owner/repo")
+            ),
+            entries
+        );
+    }
+
+    @Test
+    void subsectionMayContainDots() {
+        var entries = parseGitConfigNullOutput(
+            "http.https://github.com/.extraheader\nAUTHORIZATION: basic dG9rZW4=\0"
+        );
+
+        assertEquals(
+            List.of(new GitConfigEntry(
+                "http",
+                "https://github.com/",
+                "extraheader",
+                "AUTHORIZATION: basic dG9rZW4="
+            )),
+            entries
+        );
+    }
+
+    @Test
+    void twoSegmentKeyHasNoSubsection() {
+        var entries = parseGitConfigNullOutput("http.extraheader\nheader-value\0");
+
+        assertEquals(
+            List.of(new GitConfigEntry("http", null, "extraheader", "header-value")),
+            entries
+        );
+    }
+
+    @Test
+    void valueMayContainNewLines() {
+        var entries = parseGitConfigNullOutput("alias.log-graph\nlog\n--graph\n--oneline\0");
+
+        assertEquals(
+            List.of(new GitConfigEntry("alias", null, "log-graph", "log\n--graph\n--oneline")),
+            entries
+        );
+    }
+
+    @Test
+    void emptyOutputProducesNoEntries() {
+        assertEquals(List.of(), parseGitConfigNullOutput(""));
+    }
+
+    @Test
+    void duplicateKeysArePreservedInOrder() {
+        var entries = parseGitConfigNullOutput(
+            "http.https://github.com/.extraheader\nfirst\0http.https://github.com/.extraheader\nsecond\0"
+        );
+
+        assertEquals(
+            List.of(
+                new GitConfigEntry("http", "https://github.com/", "extraheader", "first"),
+                new GitConfigEntry("http", "https://github.com/", "extraheader", "second")
+            ),
+            entries
+        );
+    }
+
+    @Test
+    void valueLessEntryHasNullValue() {
+        var entries = parseGitConfigNullOutput("http.https://github.com/.extraheader\0");
+
+        assertEquals(1, entries.size());
+        var entry = entries.get(0);
+        assertEquals("http", entry.getSection());
+        assertEquals("https://github.com/", entry.getSubsection());
+        assertEquals("extraheader", entry.getName());
+        assertNull(entry.getValue(), "a value-less entry must have a null value");
+    }
+
+}

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtilsTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubApiTokenUtilsTest.java
@@ -1,11 +1,12 @@
 package name.remal.gradle_plugins.github_repository_info;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfig;
+import static name.remal.gradle_plugins.github_repository_info.GitHubApiTokenUtils.extractGitHubApiTokenFromGitConfigEntries;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class GitHubApiTokenUtilsTest {
@@ -13,211 +14,206 @@ class GitHubApiTokenUtilsTest {
     private static final String GITHUB_SERVER_URL = "https://github.com";
 
     @Test
-    void tokenPersistedByCheckoutActionIsExtracted() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void tokenPersistedByCheckoutActionIsExtracted() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:token-value"))
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void trailingSlashesOfSubsectionAndServerUrlAreIgnored() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void trailingSlashesOfSubsectionAndServerUrlAreIgnored() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com", basicExtraHeader("x-access-token:token-value"))
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, "https://github.com/"));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, "https://github.com/"));
     }
 
     @Test
-    void subsectionIsMatchedCaseInsensitively() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://GitHub.COM/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void subsectionIsMatchedCaseInsensitively() {
+        var entries = List.of(
+            extraHeaderEntry("https://GitHub.COM/", basicExtraHeader("x-access-token:token-value"))
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void headerNameIsMatchedCaseInsensitively() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = authorization: basic " + base64("x-access-token:token-value")
+    void headerNameIsMatchedCaseInsensitively() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", "authorization: basic " + base64("x-access-token:token-value"))
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void schemeIsMatchedCaseInsensitively() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = AUTHORIZATION: Basic " + base64("x-access-token:token-value")
+    void schemeIsMatchedCaseInsensitively() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", "AUTHORIZATION: Basic " + base64("x-access-token:token-value"))
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void colonsInsideTokenArePreserved() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token:with:colons")
+    void colonsInsideTokenArePreserved() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:token:with:colons"))
         );
 
-        assertEquals("token:with:colons", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token:with:colons", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void lastValueWins() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:first-token"),
-            "\textraheader = " + basicExtraHeader("x-access-token:second-token")
+    void lastValueWins() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:first-token")),
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:second-token"))
         );
 
-        assertEquals("second-token", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("second-token", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void unparseableValueDoesNotOverridePrecedingParsedValue() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value"),
-            "\textraheader = AUTHORIZATION: bearer some-token"
+    void unparseableValueDoesNotOverridePrecedingParsedValue() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:token-value")),
+            extraHeaderEntry("https://github.com/", "AUTHORIZATION: bearer some-token")
         );
 
-        assertEquals("token-value", extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL));
+        assertEquals("token-value", extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL));
     }
 
     @Test
-    void notMatchingSubsectionProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.example.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void notMatchingSubsectionProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.example.com/", basicExtraHeader("x-access-token:token-value"))
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from a section of another server URL"
         );
     }
 
     @Test
-    void notAuthorizationHeaderProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = X-Custom-Header: basic " + base64("x-access-token:token-value")
+    void notAuthorizationHeaderProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", "X-Custom-Header: basic " + base64("x-access-token:token-value"))
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from a header other than Authorization"
         );
     }
 
     @Test
-    void notBasicSchemeProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = AUTHORIZATION: bearer some-token"
+    void notBasicSchemeProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", "AUTHORIZATION: bearer some-token")
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from a scheme other than basic"
         );
     }
 
     @Test
-    void invalidBase64ProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = AUTHORIZATION: basic !!!not-base64!!!"
+    void invalidBase64ProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", "AUTHORIZATION: basic !!!not-base64!!!")
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from invalid Base64 credentials"
         );
     }
 
     @Test
-    void credentialsWithoutColonProduceNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("credentials-without-colon")
+    void credentialsWithoutColonProduceNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("credentials-without-colon"))
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from credentials without a colon"
         );
     }
 
     @Test
-    void emptyTokenProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:")
+    void emptyTokenProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:"))
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "empty token extracted"
         );
     }
 
     @Test
-    void subsectionLessHttpSectionIsIgnored() throws Throwable {
-        var config = gitConfig(
-            "[http]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void subsectionLessHttpEntryIsIgnored() {
+        var entries = List.of(
+            new GitConfigEntry("http", null, "extraheader", basicExtraHeader("x-access-token:token-value"))
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
             "token extracted from a subsection-less [http] section"
         );
     }
 
     @Test
-    void configWithoutHttpSectionProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[remote \"origin\"]",
-            "\turl = https://github.com/remal-gradle-plugins/github-repository-info"
+    void valueLessEntryProducesNoToken() {
+        var entries = List.of(
+            new GitConfigEntry("http", "https://github.com/", "extraheader", null)
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, GITHUB_SERVER_URL),
-            "token extracted from a config without [http] sections"
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
+            "token extracted from a value-less entry"
         );
     }
 
     @Test
-    void nullOrEmptyServerUrlProducesNoToken() throws Throwable {
-        var config = gitConfig(
-            "[http \"https://github.com/\"]",
-            "\textraheader = " + basicExtraHeader("x-access-token:token-value")
+    void entriesWithoutHttpSectionProduceNoToken() {
+        var entries = List.of(
+            new GitConfigEntry("remote", "origin", "url", "https://github.com/remal-gradle-plugins/github-repository-info")
         );
 
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, null),
+            extractGitHubApiTokenFromGitConfigEntries(entries, GITHUB_SERVER_URL),
+            "token extracted from entries without [http] sections"
+        );
+    }
+
+    @Test
+    void nullOrEmptyServerUrlProducesNoToken() {
+        var entries = List.of(
+            extraHeaderEntry("https://github.com/", basicExtraHeader("x-access-token:token-value"))
+        );
+
+        assertNull(
+            extractGitHubApiTokenFromGitConfigEntries(entries, null),
             "token extracted for a null server URL"
         );
         assertNull(
-            extractGitHubApiTokenFromGitConfig(config, ""),
+            extractGitHubApiTokenFromGitConfigEntries(entries, ""),
             "token extracted for an empty server URL"
         );
     }
 
 
-    private static String gitConfig(String... lines) {
-        return String.join("\n", lines) + "\n";
+    private static GitConfigEntry extraHeaderEntry(String subsection, String extraHeader) {
+        return new GitConfigEntry("http", subsection, "extraheader", extraHeader);
     }
 
     private static String basicExtraHeader(String rawCredentials) {

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoPluginTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitHubRepositoryInfoPluginTest.java
@@ -1,8 +1,8 @@
 package name.remal.gradle_plugins.github_repository_info;
 
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.createDirectories;
-import static java.nio.file.Files.writeString;
+import static java.util.Arrays.asList;
 import static name.remal.gradle_plugins.toolkit.reflection.ReflectionUtils.packageNameOf;
 import static name.remal.gradle_plugins.toolkit.reflection.ReflectionUtils.unwrapGeneratedSubclass;
 import static name.remal.gradle_plugins.toolkit.testkit.ProjectValidations.executeAfterEvaluateActions;
@@ -11,9 +11,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +31,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.io.TempDir;
 
 @RequiredArgsConstructor
 @SuppressWarnings("java:S5778")
@@ -93,23 +97,107 @@ class GitHubRepositoryInfoPluginTest {
         }
 
         @Test
-        @DisabledIfEnvironmentVariable(named = "GITHUB_TOKEN", matches = ".+")
-        @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
-        void tokenIsReadFromRepositoryGitConfig() throws Throwable {
-            writeProjectGitConfig(
-                "[http \"https://github.com/\"]",
-                "\textraheader = AUTHORIZATION: basic " + base64("x-access-token:" + SYNTHETIC_TOKEN)
+        void tokenIsExtractedFromDirectExtraHeader() throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--local",
+                "http.https://github.com/.extraheader",
+                basicAuthorizationExtraHeader(SYNTHETIC_TOKEN)
             );
 
-            assertEquals(SYNTHETIC_TOKEN, extension.getGithubApiToken().getOrNull());
+            assertEquals(SYNTHETIC_TOKEN, extension.getGitHubApiTokenFromGitConfig().getOrNull());
+        }
+
+        @Test
+        void tokenIsExtractedFromIncludeIfReferencedCredentialsFile(@TempDir Path credentialsDir) throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            var credentialsFile = writeCredentialsFile(credentialsDir);
+
+            var gitDirPattern = toGitPathPattern(project.getProjectDir().toPath().resolve(".git").toRealPath());
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--local",
+                "includeIf.gitdir:" + gitDirPattern + ".path",
+                credentialsFile.toString()
+            );
+
+            assertEquals(SYNTHETIC_TOKEN, extension.getGitHubApiTokenFromGitConfig().getOrNull());
+        }
+
+        @Test
+        void tokenIsAbsentWhenIncludeIfGitDirDoesNotMatch(
+            @TempDir Path credentialsDir,
+            @TempDir Path notMatchingDir
+        ) throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            var credentialsFile = writeCredentialsFile(credentialsDir);
+
+            var notMatchingGitDirPattern = toGitPathPattern(notMatchingDir.toRealPath().resolve(".git"));
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--local",
+                "includeIf.gitdir:" + notMatchingGitDirPattern + ".path",
+                credentialsFile.toString()
+            );
+
+            assertNull(
+                extension.getGitHubApiTokenFromGitConfig().getOrNull(),
+                "token extracted from a credentials file behind a not matching includeIf condition"
+            );
+        }
+
+        @Test
+        void tokenIsAbsentWhenGitConfigHasNoExtraHeader() throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            executeGit(
+                project.getProjectDir(),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/remal-gradle-plugins/github-repository-info"
+            );
+
+            assertNull(
+                extension.getGitHubApiTokenFromGitConfig().getOrNull(),
+                "token extracted from a git config without extraheader entries"
+            );
+        }
+
+        @Test
+        void notGitRepositoryProducesActionableError() {
+            // the project directory is deliberately not initialized as a git repository
+            var tokenProvider = extension.getGitHubApiTokenFromGitConfig();
+            var exception = assertThrows(Exception.class, tokenProvider::getOrNull);
+
+            var messages = getAllMessages(exception);
+            assertTrue(
+                messages.contains("git config"),
+                () -> "error messages must mention the executed git command:\n" + messages
+            );
+            assertTrue(
+                messages.contains("exit code 128"),
+                () -> "error messages must include the git exit code:\n" + messages
+            );
+            assertTrue(
+                messages.contains(project.getProjectDir().toString()),
+                () -> "error messages must include the working directory:\n" + messages
+            );
         }
 
         @Test
         @EnabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
         void environmentVariableWinsOverGitConfig() throws Throwable {
-            writeProjectGitConfig(
-                "[http \"https://github.com/\"]",
-                "\textraheader = AUTHORIZATION: basic " + base64("x-access-token:" + SYNTHETIC_TOKEN)
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--local",
+                "http.https://github.com/.extraheader",
+                basicAuthorizationExtraHeader(SYNTHETIC_TOKEN)
             );
 
             var expectedToken = System.getenv("GITHUB_TOKEN") != null
@@ -123,29 +211,124 @@ class GitHubRepositoryInfoPluginTest {
         @Test
         @DisabledIfEnvironmentVariable(named = "GITHUB_TOKEN", matches = ".+")
         @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS_TOKEN", matches = ".+")
-        void tokenIsAbsentWhenGitConfigHasNoExtraHeader() throws Throwable {
-            writeProjectGitConfig(
-                "[remote \"origin\"]",
-                "\turl = https://github.com/remal-gradle-plugins/github-repository-info"
+        void tokenIsReadFromRepositoryGitConfig() throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--local",
+                "http.https://github.com/.extraheader",
+                basicAuthorizationExtraHeader(SYNTHETIC_TOKEN)
             );
+
+            assertEquals(SYNTHETIC_TOKEN, extension.getGithubApiToken().getOrNull());
+        }
+
+
+        private Path writeCredentialsFile(Path credentialsDir) throws Exception {
+            var credentialsFile = credentialsDir.resolve("git-credentials-test.config");
+            executeGit(
+                project.getProjectDir(),
+                "config",
+                "--file",
+                credentialsFile.toString(),
+                "http.https://github.com/.extraheader",
+                basicAuthorizationExtraHeader(SYNTHETIC_TOKEN)
+            );
+            return credentialsFile;
+        }
+
+        private String basicAuthorizationExtraHeader(String token) {
+            var credentials = "x-access-token:" + token;
+            return "AUTHORIZATION: basic " + Base64.getEncoder().encodeToString(credentials.getBytes(UTF_8));
+        }
+
+    }
+
+    @Nested
+    class GitRemoteDetection {
+
+        GitHubRepositoryInfoExtension extension;
+
+        @BeforeEach
+        void beforeEach() {
+            extension = project.getExtensions().getByType(GitHubRepositoryInfoExtension.class);
+            extension.getRepositoryRootDir().fileValue(project.getProjectDir());
+        }
+
+        @Test
+        void originRemoteIsPreferredForRemoteInfo() throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
+            executeGit(
+                project.getProjectDir(),
+                "remote",
+                "add",
+                "aaa-remote",
+                "https://example.com/other/repository.git"
+            );
+            executeGit(
+                project.getProjectDir(),
+                "remote",
+                "add",
+                "origin",
+                "https://github.example.com/owner/repo.git"
+            );
+
+            assertEquals("github.example.com", extension.getGitRemoteHost().getOrNull());
+            assertEquals("owner/repo", extension.getGitRemoteRepositoryFullName().getOrNull());
+        }
+
+        @Test
+        void remoteInfoIsAbsentWithoutRemotes() throws Throwable {
+            executeGit(project.getProjectDir(), "init", "--quiet");
 
             assertNull(
-                extension.getGithubApiToken().getOrNull(),
-                "githubApiToken resolved without any token source"
+                extension.getGitRemoteHost().getOrNull(),
+                "git remote host detected in a repository without remotes"
+            );
+            assertNull(
+                extension.getGitRemoteRepositoryFullName().getOrNull(),
+                "git remote repository full name detected in a repository without remotes"
             );
         }
 
+    }
 
-        private void writeProjectGitConfig(String... lines) throws IOException {
-            var gitConfigPath = project.getProjectDir().toPath().resolve(".git").resolve("config");
-            createDirectories(gitConfigPath.getParent());
-            writeString(gitConfigPath, String.join("\n", lines) + "\n");
+
+    private static void executeGit(File workingDir, String... args) throws Exception {
+        var command = new ArrayList<String>();
+        command.add("git");
+        command.addAll(asList(args));
+
+        var process = new ProcessBuilder(command)
+            .directory(workingDir)
+            .redirectErrorStream(true)
+            .start();
+        var output = new String(process.getInputStream().readAllBytes(), UTF_8);
+        var exitCode = process.waitFor();
+        assertEquals(
+            0,
+            exitCode,
+            () -> format("Command %s failed with exit code %d:%n%s", command, exitCode, output)
+        );
+    }
+
+    /**
+     * Git matches {@code gitdir:} patterns against paths with forward slashes on all OSes.
+     */
+    private static String toGitPathPattern(Path path) {
+        return path.toString().replace(File.separatorChar, '/');
+    }
+
+    private static String getAllMessages(Throwable rootThrowable) {
+        var messages = new StringBuilder();
+        for (var throwable = rootThrowable; throwable != null; throwable = throwable.getCause()) {
+            if (messages.length() > 0) {
+                messages.append('\n');
+            }
+            messages.append(throwable);
         }
-
-        private String base64(String value) {
-            return Base64.getEncoder().encodeToString(value.getBytes(UTF_8));
-        }
-
+        return messages.toString();
     }
 
 }

--- a/src/test/java/name/remal/gradle_plugins/github_repository_info/GitRemoteUrlUtilsTest.java
+++ b/src/test/java/name/remal/gradle_plugins/github_repository_info/GitRemoteUrlUtilsTest.java
@@ -1,0 +1,103 @@
+package name.remal.gradle_plugins.github_repository_info;
+
+import static name.remal.gradle_plugins.github_repository_info.GitRemoteUrlUtils.getRemoteUrlHost;
+import static name.remal.gradle_plugins.github_repository_info.GitRemoteUrlUtils.getRemoteUrlPath;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class GitRemoteUrlUtilsTest {
+
+    @Test
+    void httpsUrl() {
+        assertEquals("github.com", getRemoteUrlHost("https://github.com/owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("https://github.com/owner/repo.git"));
+    }
+
+    @Test
+    void httpsUrlWithoutDotGitExtension() {
+        assertEquals("github.com", getRemoteUrlHost("https://github.com/owner/repo"));
+        assertEquals("owner/repo", getRemoteUrlPath("https://github.com/owner/repo"));
+    }
+
+    @Test
+    void scpLikeSyntax() {
+        assertEquals("github.com", getRemoteUrlHost("git@github.com:owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("git@github.com:owner/repo.git"));
+    }
+
+    @Test
+    void scpLikeSyntaxWithoutUser() {
+        assertEquals("github.com", getRemoteUrlHost("github.com:owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("github.com:owner/repo.git"));
+    }
+
+    @Test
+    void sshUrl() {
+        assertEquals("github.com", getRemoteUrlHost("ssh://git@github.com/owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("ssh://git@github.com/owner/repo.git"));
+    }
+
+    @Test
+    void gitUrl() {
+        assertEquals("github.com", getRemoteUrlHost("git://github.com/owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("git://github.com/owner/repo.git"));
+    }
+
+    @Test
+    void urlWithPort() {
+        assertEquals("github.example.com", getRemoteUrlHost("https://github.example.com:8443/owner/repo.git"));
+        assertEquals("owner/repo", getRemoteUrlPath("https://github.example.com:8443/owner/repo.git"));
+    }
+
+    @Test
+    void urlWithoutPath() {
+        assertEquals("github.com", getRemoteUrlHost("https://github.com"));
+        assertNull(
+            getRemoteUrlPath("https://github.com"),
+            "a path extracted from a URL without a path"
+        );
+    }
+
+    @Test
+    void dotGitExtensionIsStrippedOnlyAtTheEnd() {
+        assertEquals(
+            "owner/owner.github.io",
+            getRemoteUrlPath("https://github.com/owner/owner.github.io.git")
+        );
+        assertEquals(
+            "owner/owner.github.io",
+            getRemoteUrlPath("https://github.com/owner/owner.github.io")
+        );
+    }
+
+    @Test
+    void emptyPathProducesNull() {
+        assertNull(
+            getRemoteUrlPath("https://github.com/"),
+            "a path extracted from a URL with an empty path"
+        );
+        assertNull(
+            getRemoteUrlPath("https://github.com/.git"),
+            "a path extracted from a URL whose path is only the .git extension"
+        );
+    }
+
+    @Test
+    void localPathsProduceNoHost() {
+        assertNull(
+            getRemoteUrlHost("/srv/git/repo.git"),
+            "a host extracted from a local absolute path"
+        );
+        assertNull(
+            getRemoteUrlHost("C:/projects/repo.git"),
+            "a host extracted from a Windows drive letter path"
+        );
+        assertNull(
+            getRemoteUrlHost("C:\\projects\\repo.git"),
+            "a host extracted from a Windows drive letter path with backslashes"
+        );
+    }
+
+}


### PR DESCRIPTION
## Summary

The plugin's last-resort GitHub API token source reads the credential that [actions/checkout](https://github.com/actions/checkout) persists in the repository git config, but since checkout v4.3.1 / v5.0.1 / v6 ([Persist creds to a separate file](https://github.com/actions/checkout/pull/2286)) that credential lives in a separate file referenced from `.git/config` via `includeIf`, which JGit does not support ([Conditional Include in gitconfig](https://github.com/eclipse-jgit/jgit/issues/9)), so the fallback silently found nothing on current checkout versions.

## High-level changes

- Reading the repository git config is delegated to the `git` CLI (`git config --local --includes --list --null`), so git itself resolves `include`/`includeIf`; git remote detection (host and repository full name) moves onto the same invocation, removing JGit entirely.
- macOS and Windows CI test jobs are added, since the plugin now shells out to the platform's `git` executable.
